### PR TITLE
[fix]: disable transitions on theme change

### DIFF
--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -1,31 +1,15 @@
 "use client";
-import { Github, Moon, Sun, Twitter } from "lucide-react";
-import Image from "next/image";
+import { Github, Moon, Sun } from "lucide-react";
 import Link from "next/link";
 import React, { useEffect, useState } from "react";
-import logo from "../../../public/mixuiLogo.png";
 import { usePathname } from "next/navigation";
+import { useTheme } from "@/lib/hooks/useTheme";
 
 function Navbar() {
   const pathname = usePathname();
   const isDocsPage = pathname?.includes("docs");
 
-  const [theme, setTheme] = useState("light"); // Default to 'light'
-
-  useEffect(() => {
-    // Load theme from localStorage
-    const savedTheme = localStorage.getItem("theme") || "light";
-    setTheme(savedTheme);
-    document.documentElement.classList.add(savedTheme);
-  }, []);
-
-  const toggleTheme = () => {
-    const newTheme = theme === "light" ? "dark" : "light";
-    setTheme(newTheme);
-    document.documentElement.classList.remove(theme);
-    document.documentElement.classList.add(newTheme);
-    localStorage.setItem("theme", newTheme);
-  };
+  const { theme, toggleTheme } = useTheme();
 
   return (
     <header className="bg-white dark:bg-[#020817] w-full border-b">
@@ -88,7 +72,7 @@ function Navbar() {
                 href="https://github.com/taqui-786/mixui"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex items-center gap-2 px-4 py-2 rounded-lg 
+                className="flex items-center gap-2 px-4 py-2 rounded-lg
                   transition-all duration-200 ease-in-out
                   dark:hover:bg-gray-500
                   hover:bg-gray-100 hover:scale-[1.02]

--- a/src/lib/hooks/useTheme.tsx
+++ b/src/lib/hooks/useTheme.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export function useTheme() {
+  const [theme, setTheme] = useState("light"); // Default to 'light'
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prevTheme) => {
+      let newTheme = prevTheme === "light" ? "dark" : "light";
+      document.documentElement.classList.remove(theme);
+      document.documentElement.classList.add(newTheme);
+      localStorage.setItem("theme", newTheme);
+
+      return newTheme;
+    });
+  }, [theme]);
+
+  // use theme from localStorage on first load
+  useEffect(() => {
+    const savedTheme = localStorage.getItem("theme") || "light";
+    setTheme(savedTheme);
+    document.documentElement.classList.add(savedTheme);
+  }, []);
+
+  //disable animation whenever the theme changes, see:
+  // https://github.com/pacocoursey/next-themes/blob/main/next-themes/src/index.tsx#L225
+  useEffect(() => {
+    const css = document.createElement("style");
+    css.appendChild(
+      document.createTextNode(
+        `*,*::before,*::after{-webkit-transition:none!important;-moz-transition:none!important;-o-transition:none!important;-ms-transition:none!important;transition:none!important}`
+      )
+    );
+
+    document.head.appendChild(css);
+
+    return () => {
+      (() => window.getComputedStyle(document.body))();
+
+      setTimeout(() => {
+        document.head.removeChild(css);
+      }, 1);
+    };
+  }, [theme]);
+
+  return { theme, toggleTheme };
+}


### PR DESCRIPTION
### Problem: Transitions on theme change.

When `transition-property: color` or `transition-property: all` and `transition-duration`  are applied components, they cause a visible delay in component color update on theme change.

### Example:
[69d4ae56-e6f8-4dbb-bc60-69eb258d9cbf.webm](https://github.com/user-attachments/assets/195f374d-b8aa-4228-aadf-45861a644564)

### Solution:
Disable all animations whenever a theme change occurs.