### PR TITLE
Components page is scrollable now

### DIFF
--- a/src/app/components/page.tsx
+++ b/src/app/components/page.tsx
@@ -87,7 +87,7 @@ function ComponentsPage() {
         {filteredComponents.map((component, index) => (
           <div
             key={index}
-            className="group flex flex-col bg-card border rounded-xl shadow-sm hover:shadow-md transition-all duration-200 justify-between items-start gap-y-8"
+            className="group flex flex-col bg-card border rounded-xl shadow-sm hover:shadow-md transition-all duration-200 justify-between items-start gap-y-8 w-full"
           >
             {/* Preview Section - Updated */}
             <div className="relative p-8 md:p-4 w-full bg-muted border-b h-full min-h-[10rem]">
@@ -104,7 +104,7 @@ function ComponentsPage() {
             </div>
 
             {/* Content Section - Updated */}
-            <div className="p-5 flex flex-col flex-grow">
+            <div className="p-5 flex flex-col flex-grow w-full">
               <h3 className="text-xl font-semibold text-foreground mb-2">
                 {component.title}
               </h3>

--- a/src/app/components/page.tsx
+++ b/src/app/components/page.tsx
@@ -87,10 +87,10 @@ function ComponentsPage() {
         {filteredComponents.map((component, index) => (
           <div
             key={index}
-            className="group flex flex-col bg-card border rounded-xl shadow-sm hover:shadow-md transition-all duration-200 overflow-hidden"
+            className="group flex flex-col bg-card border rounded-xl shadow-sm hover:shadow-md transition-all duration-200 justify-between items-start gap-y-8"
           >
             {/* Preview Section - Updated */}
-            <div className="relative min-h-[200px] md:min-h-[250px] w-full bg-muted border-b">
+            <div className="relative p-8 md:p-4 w-full bg-muted border-b h-full min-h-[10rem]">
               <div className="absolute inset-0 flex justify-center items-center p-6 overflow-hidden">
                 <div className="transform-gpu transition-transform duration-300 group-hover:scale-105 w-full flex justify-center items-center">
                   <div className="max-w-full max-h-full overflow-auto flex justify-center items-center">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}><main
           className={cn(
-            "flex flex-col relative w-screen break-words h-full min-h-dvh"
+            "flex flex-col relative w-full break-words h-full min-h-dvh max-w-full"
           )}
         >
           {/* NAVBAR ->  */}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}><main
           className={cn(
-            "flex flex-col relative w-screen break-words h-dvh overflow-hidden "
+            "flex flex-col relative w-screen break-words h-full min-h-dvh"
           )}
         >
           {/* NAVBAR ->  */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -134,9 +134,9 @@ export default function Home() {
                 className="size-8"
                 fill="none"
                 stroke="currentColor"
-                stroke-width="1"
-                stroke-linecap="round"
-                stroke-linejoin="round"
+                strokeWidth="1"
+                strokeLinecap="round"
+                strokeLinejoin="round"
               >
                 <title>Framer Motion</title>
                 <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>


### PR DESCRIPTION
Before This PR, the components page was of fixed height, and the container had a property of `overflow:hidden` which made it hard to view the page, or even use it to view any of the components. 
